### PR TITLE
Feat: better `/summary` routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ app.get("/summaries", (req, res) => {
 });
 
 app.get("/summary/:catchupNumber", (req, res) => {
-	let catchupNumber = req.params.catchupNumber;
+	let catchupNumber = req.params.catchupNumber.toLowerCase();
 	if (catchupNumber == "latest" || catchupNumber == "random") {
 		let sortedCatchupNumbers = fs
 			.readdirSync(__dirname + `/public/html/summary`)

--- a/index.js
+++ b/index.js
@@ -45,23 +45,14 @@ app.get("/summaries", (req, res) => {
 
 app.get("/summary/:catchupNumber", (req, res) => {
 	let catchupNumber = req.params.catchupNumber;
-	const originalCatchUpNumber = catchupNumber;
+	let parsedCatchupNumber = parseInt(catchupNumber).toString();
+	let normalizedCatchupNumber = parsedCatchupNumber.padStart(3, "0");
 
-	if (isNaN(parseInt(catchupNumber))) {
-		res.status(404).sendFile(__dirname + "/public/html/404.html");
-		return;
-	}
-
-	if (catchupNumber.length === 1) catchupNumber = "00" + catchupNumber;
-	if (catchupNumber.length === 2) catchupNumber = "0" + catchupNumber;
-	const path = __dirname + `/public/html/summary/${catchupNumber}.html`;
-
+	const path =
+		__dirname + `/public/html/summary/${normalizedCatchupNumber}.html`;
 	if (fs.existsSync(path)) {
-		if (
-			originalCatchUpNumber.length === 1 ||
-			originalCatchUpNumber.length === 2
-		)
-			res.redirect(`/summary/${catchupNumber}`);
+		if (catchupNumber != parsedCatchupNumber)
+			res.redirect(`/summary/${parsedCatchupNumber}`);
 		else res.sendFile(path);
 	} else res.status(404).sendFile(__dirname + "/public/html/404.html");
 });

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ app.get("/summaries", (req, res) => {
 
 app.get("/summary/:catchupNumber", (req, res) => {
 	let catchupNumber = req.params.catchupNumber.toLowerCase();
-	if (catchupNumber == "latest" || catchupNumber == "random") {
+	if (catchupNumber === "latest" || catchupNumber === "random") {
 		let sortedCatchupNumbers = fs
 			.readdirSync(__dirname + `/public/html/summary`)
 			.map((file) => parseInt(file.replace(/\.html/, "")))
@@ -53,8 +53,8 @@ app.get("/summary/:catchupNumber", (req, res) => {
 			.sort((a, b) => b - a);
 
 		let index = -1;
-		if (catchupNumber == "latest") index = 0;
-		else if (catchupNumber == "random")
+		if (catchupNumber === "latest") index = 0;
+		else if (catchupNumber === "random")
 			index = Math.floor(Math.random() * sortedCatchupNumbers.length);
 		res.redirect(`/summary/${sortedCatchupNumbers[index]}`);
 		return;
@@ -66,7 +66,7 @@ app.get("/summary/:catchupNumber", (req, res) => {
 	const path =
 		__dirname + `/public/html/summary/${normalizedCatchupNumber}.html`;
 	if (fs.existsSync(path)) {
-		if (catchupNumber != parsedCatchupNumber)
+		if (catchupNumber !== parsedCatchupNumber)
 			res.redirect(`/summary/${parsedCatchupNumber}`);
 		else res.sendFile(path);
 	} else res.status(404).sendFile(__dirname + "/public/html/404.html");

--- a/index.js
+++ b/index.js
@@ -45,15 +45,18 @@ app.get("/summaries", (req, res) => {
 
 app.get("/summary/:catchupNumber", (req, res) => {
 	let catchupNumber = req.params.catchupNumber;
-	if (catchupNumber == "latest") {
+	if (catchupNumber == "latest" || catchupNumber == "random") {
 		let sortedCatchupNumbers = fs
 			.readdirSync(__dirname + `/public/html/summary`)
 			.map((file) => parseInt(file.replace(/\.html/, "")))
 			.filter((number) => !Number.isNaN(number))
 			.sort((a, b) => b - a);
 
-		let latestCatchupNumber = sortedCatchupNumbers[0].toString();
-		res.redirect(`/summary/${latestCatchupNumber}`);
+		let index = -1;
+		if (catchupNumber == "latest") index = 0;
+		else if (catchupNumber == "random")
+			index = Math.floor(Math.random() * sortedCatchupNumbers.length);
+		res.redirect(`/summary/${sortedCatchupNumbers[index]}`);
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,18 @@ app.get("/summaries", (req, res) => {
 
 app.get("/summary/:catchupNumber", (req, res) => {
 	let catchupNumber = req.params.catchupNumber;
+	if (catchupNumber == "latest") {
+		let sortedCatchupNumbers = fs
+			.readdirSync(__dirname + `/public/html/summary`)
+			.map((file) => parseInt(file.replace(/\.html/, "")))
+			.filter((number) => !Number.isNaN(number))
+			.sort((a, b) => b - a);
+
+		let latestCatchupNumber = sortedCatchupNumbers[0].toString();
+		res.redirect(`/summary/${latestCatchupNumber}`);
+		return;
+	}
+
 	let parsedCatchupNumber = parseInt(catchupNumber).toString();
 	let normalizedCatchupNumber = parsedCatchupNumber.padStart(3, "0");
 

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ app.get("/summaries", (req, res) => {
 app.get("/summary/:catchupNumber", (req, res) => {
 	let catchupNumber = req.params.catchupNumber.toLowerCase();
 	if (catchupNumber === "latest" || catchupNumber === "random") {
+		// get summary numbers in descending order
 		let sortedCatchupNumbers = fs
 			.readdirSync(__dirname + `/public/html/summary`)
 			.map((file) => parseInt(file.replace(/\.html/, "")))
@@ -66,6 +67,7 @@ app.get("/summary/:catchupNumber", (req, res) => {
 	const path =
 		__dirname + `/public/html/summary/${normalizedCatchupNumber}.html`;
 	if (fs.existsSync(path)) {
+		// if entered path is not canonical, redirect to the canonical path
 		if (catchupNumber !== parsedCatchupNumber)
 			res.redirect(`/summary/${parsedCatchupNumber}`);
 		else res.sendFile(path);

--- a/public/html/404.html
+++ b/public/html/404.html
@@ -136,7 +136,7 @@
 			<a class="black-bg-cta" href="/summary/latest">
 				Read Latest Summary
 			</a>
-			<a class="black-bg-cta" href="/summary">All Summaries</a>
+			<a class="black-bg-cta" href="/summary">Read All Summaries</a>
 			<a class="black-bg-cta" href="/showcase">Showcase a Project</a>
 		</div>
 

--- a/public/html/404.html
+++ b/public/html/404.html
@@ -119,14 +119,24 @@
 		</h2>
 
 		<div class="error-msg hidden">
-			NOTE: OTC CatchUp is not in session right now. Please come back on
-			Saturday (10:30 PM IST onwards), we would love to have you! Feel
-			free to <a href="/summary">read our session summaries</a> till then.
+			<p>NOTE: OTC CatchUp is not in session right now.</p>
+			<p>
+				Please come back on Saturday (10:30 PM IST onwards), we would
+				love to have you!
+			</p>
+			<p>
+				Till then, feel free to read the
+				<a href="/summary/latest">latest summary</a> or
+				<a href="/summary">all session summaries</a>.
+			</p>
 		</div>
 
 		<div id="cta-wrapper">
 			<a id="white-bg-cta" href="/attend">Join the CatchUp meet</a>
-			<a class="black-bg-cta" href="/summary">CatchUp Summaries</a>
+			<a class="black-bg-cta" href="/summary/latest">
+				Read Latest Summary
+			</a>
+			<a class="black-bg-cta" href="/summary">All Summaries</a>
 			<a class="black-bg-cta" href="/showcase">Showcase a Project</a>
 		</div>
 

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -122,14 +122,24 @@
 		<h2>Informal Tech discussions every Saturday from 10:30 PM IST</h2>
 
 		<div class="error-msg hidden">
-			NOTE: OTC CatchUp is not in session right now. Please come back on
-			Saturday (10:30 PM IST onwards), we would love to have you! Feel
-			free to <a href="/summary">read our session summaries</a> till then.
+			<p>NOTE: OTC CatchUp is not in session right now.</p>
+			<p>
+				Please come back on Saturday (10:30 PM IST onwards), we would
+				love to have you!
+			</p>
+			<p>
+				Till then, feel free to read the
+				<a href="/summary/latest">latest summary</a> or
+				<a href="/summary">all session summaries</a>.
+			</p>
 		</div>
 
 		<div id="cta-wrapper">
 			<a id="white-bg-cta" href="/attend">Join the CatchUp Meet</a>
-			<a class="black-bg-cta" href="/summary">Read CatchUp Summaries</a>
+			<a class="black-bg-cta" href="/summary/latest">
+				Read Latest Summary
+			</a>
+			<a class="black-bg-cta" href="/summary">All Summaries</a>
 			<a class="black-bg-cta" href="/showcase">Showcase a Project</a>
 			<a class="black-bg-cta" href="/cfp">Give a Talk</a>
 		</div>

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -139,7 +139,7 @@
 			<a class="black-bg-cta" href="/summary/latest">
 				Read Latest Summary
 			</a>
-			<a class="black-bg-cta" href="/summary">All Summaries</a>
+			<a class="black-bg-cta" href="/summary">Read All Summaries</a>
 			<a class="black-bg-cta" href="/showcase">Showcase a Project</a>
 			<a class="black-bg-cta" href="/cfp">Give a Talk</a>
 		</div>


### PR DESCRIPTION
- Use canonical numbering for `/summary/:catchupNumber` route
- Add route `/summary/latest` to redirect to latest summary
- Add route `/summary/random` to redirect to a random summary
- misc: Add linebreaks to error message in 404 and index.html