### PR TITLE
Fix: overflow of video element on screen width less than 700px

### DIFF
--- a/summary/static/css/summary-style.css
+++ b/summary/static/css/summary-style.css
@@ -299,6 +299,6 @@ samp {
 	font-family: "PT Mono", monospace;
 }
 
-video{
+video {
 	width: 100%;
 }

--- a/summary/static/css/summary-style.css
+++ b/summary/static/css/summary-style.css
@@ -298,3 +298,7 @@ pre,
 samp {
 	font-family: "PT Mono", monospace;
 }
+
+video{
+	width: 100%;
+}


### PR DESCRIPTION
Closes #132 

The video now takes the 100% available space according to the device width, the box sizing property makes sure that the padding and margin remains intact.