### PR TITLE
fix: prevent overwriting existing handles (#175)

### DIFF
--- a/util/create-attendee-handle-map.js
+++ b/util/create-attendee-handle-map.js
@@ -47,7 +47,9 @@ function collectUsernames(fileContents, filePath) {
 		if (link && name) {
 			globalMap.set(name, link);
 		} else if (onlyName) {
-			globalMap.set(onlyName, null);
+			if (!globalMap.get(onlyName)) {
+				globalMap.set(onlyName, null);
+			}
 		} else {
 			console.warn(`Error parsing line: ${line}, filePath: ${filePath}`);
 		}


### PR DESCRIPTION
Closes #175

I tested the old behavior and it did overwrite the x.com link I had across all catchups once I edited attendees.doc  of session 289

```json
{
    "name": "Bhavesh Kukreja",
    "handle": null
}
```

After applying the changes it showed the expected behavior
```json
{
    "name": "Bhavesh Kukreja",
    "handle": "https://twitter.com/bhavesh878789"
}
```